### PR TITLE
removed cmux and add only grpc port

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Debug      bool
 	Origin     string
 	Port       string `default:"8080"`
+	GrpcPort   string `default:"50051"`
 	SSE        ServerSentEvent
 	Subscriber Subscriber
 	TLS        Cert `envconfig:"TLS"`

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 372a7e58b4ec1ec6441b95a341f37035012205a8ef7048d6b56326b76fc73c19
-updated: 2017-05-07T18:14:22.00552573+09:00
+hash: bea123a9adafdd81b72bbe45711b296c12c128e70ed0e18477e960aea126cb59
+updated: 2017-05-20T00:41:47.512136265+09:00
 imports:
 - name: github.com/golang/protobuf
   version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
@@ -16,12 +16,10 @@ imports:
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/rcrowley/go-metrics
   version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
-- name: github.com/soheilhy/cmux
-  version: 0068a46c9c22b4cd1aef5b063a9a47f473826d52
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: go.uber.org/zap
-  version: 6a4e056f2cc954cfec3581729e758909604b3f76
+  version: fab453050a7a08c35f31fc5fff6f2dbd962285ab
   subpackages:
   - buffer
   - internal/bufferpool

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,8 +11,6 @@ import:
 - package: github.com/pkg/errors
   version: ^0.8.0
 - package: github.com/rcrowley/go-metrics
-- package: github.com/soheilhy/cmux
-  version: 0068a46c9c22b4cd1aef5b063a9a47f473826d52
 - package: go.uber.org/zap
   version: ^1.0.0
   subpackages:

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -40,12 +40,14 @@ func TestGRPCEvents(t *testing.T) {
 	require.NoError(err)
 
 	config := config.Config{Port: "8082"}
-	grpcServer := NewGRPCServer(Option{
+	grpcServer, err := NewGRPCServer(Option{
 		PubSuber:     pb,
 		AccessLogger: logger,
 		ErrorLogger:  logger,
 		Config:       config,
 	})
+	require.NoError(err)
+
 	l, err := net.Listen("tcp", ":"+config.Port)
 	require.NoError(err)
 	go grpcServer.Serve(l)

--- a/server/meta.go
+++ b/server/meta.go
@@ -14,12 +14,6 @@ import (
 	"github.com/openfresh/plasma/metrics"
 )
 
-func NewMetaServer(opt Option) *http.Server {
-	return &http.Server{
-		Handler: newMetaHandler(opt),
-	}
-}
-
 type metaHandler struct {
 	accessLogger *zap.Logger
 	errorLogger  *zap.Logger
@@ -31,7 +25,7 @@ func (h metaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.mux.ServeHTTP(w, r)
 }
 
-func newMetaHandler(opt Option) metaHandler {
+func NewMetaHandler(opt Option) metaHandler {
 	h := metaHandler{
 		accessLogger: opt.AccessLogger,
 		errorLogger:  opt.ErrorLogger,

--- a/server/meta_test.go
+++ b/server/meta_test.go
@@ -76,7 +76,7 @@ func TestHealthCheckHandler(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		handler := newMetaHandler(Option{
+		handler := NewMetaHandler(Option{
 			AccessLogger: l,
 			ErrorLogger:  l,
 			Config: config.Config{

--- a/server/sse.go
+++ b/server/sse.go
@@ -20,12 +20,6 @@ import (
 	"github.com/openfresh/plasma/pubsub"
 )
 
-func NewSSEServer(opt Option) *http.Server {
-	return &http.Server{
-		Handler: newHandler(opt),
-	}
-}
-
 type sseHandler struct {
 	clientManager *manager.ClientManager
 	timer         *time.Ticker
@@ -40,7 +34,7 @@ type sseHandler struct {
 	config        config.Config
 }
 
-func newHandler(opt Option) sseHandler {
+func NewSSEHandler(opt Option) sseHandler {
 	h := sseHandler{
 		clientManager: manager.NewClientManager(),
 		timer:         time.NewTicker(10 * time.Second),

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -71,7 +71,7 @@ func setUpSSEHandler(t *testing.T, pb pubsub.PubSuber, origin string) sseHandler
 		ErrorLogger:  logger,
 		Config:       config,
 	}
-	handler := newHandler(opt)
+	handler := NewSSEHandler(opt)
 
 	return handler
 }


### PR DESCRIPTION
cmux cause memory leak and OOMKiller to run for a long time. cmux is very useful, but I gave up using it.

Also, routing of cmux to gRPC fails handshake depending on load balancer. Because this is very troublesome, I separated HTTP and gRPC listening port.