### PR TITLE
resolve leak goroutine problem by go-redis

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,14 @@
-hash: bea123a9adafdd81b72bbe45711b296c12c128e70ed0e18477e960aea126cb59
-updated: 2017-05-20T00:41:47.512136265+09:00
+hash: 2929a03edacd680176e51f438d907fc819cc7df420be57c0145ef43169dede1a
+updated: 2017-06-12T17:42:41.27262233+09:00
 imports:
+- name: github.com/go-redis/redis
+  version: eb066030c08c254136a0dbfe9f7a3625a0871beb
+  subpackages:
+  - internal
+  - internal/consistenthash
+  - internal/hashtag
+  - internal/pool
+  - internal/proto
 - name: github.com/golang/protobuf
   version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
   subpackages:
@@ -19,7 +27,7 @@ imports:
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: go.uber.org/zap
-  version: fab453050a7a08c35f31fc5fff6f2dbd962285ab
+  version: 9cabc84638b70e564c3dab2766efcb1ded2aac9f
   subpackages:
   - buffer
   - internal/bufferpool
@@ -53,7 +61,7 @@ imports:
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: d2e1b51f33ff8c5e4a15560ff049d200e83726c5
+  version: d8960bd63c6743defa6d54926e5edfa8e4a28e43
   subpackages:
   - codes
   - credentials
@@ -68,14 +76,8 @@ imports:
   - status
   - tap
   - transport
-- name: gopkg.in/redis.v5
-  version: a16aeec10ff407b1e7be6dd35797ccf5426ef0f0
-  subpackages:
-  - internal
-  - internal/consistenthash
-  - internal/hashtag
-  - internal/pool
-  - internal/proto
+- name: gopkg.in/redis.v6
+  version: 663bb76bcc3763c41877b63671003705a47289c5
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,8 +23,7 @@ import:
   - errgroup
 - package: google.golang.org/grpc
   version: ^1.3.0
-- package: gopkg.in/redis.v5
-  version: ^5.2.9
+- package: github.com/go-redis/redis 
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/main.go
+++ b/main.go
@@ -2,12 +2,11 @@ package main
 
 import (
 	"crypto/tls"
+	"golang.org/x/net/context"
 	"net"
 	"os"
 	"os/signal"
 	"syscall"
-
-	"golang.org/x/net/context"
 
 	"golang.org/x/sync/errgroup"
 

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -197,6 +197,7 @@ func (ss *StreamServer) Events(es proto.StreamService_EventsServer) error {
 				ss.removeClients <- client
 				return err
 			}
+
 		case <-ss.forceCloseChan:
 			ss.removeClients <- client
 			return nil

--- a/server/meta_test.go
+++ b/server/meta_test.go
@@ -37,7 +37,15 @@ func TestCheckRedis(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		err := checkRedis(c.Redis)
+		h := NewMetaHandler(Option{
+			Config: config.Config{
+				Subscriber: config.Subscriber{
+					Redis: c.Redis,
+				},
+			},
+		})
+
+		err := h.checkRedis()
 		if c.IsErr {
 			assert.NotNil(err)
 		} else {

--- a/subscriber/redis.go
+++ b/subscriber/redis.go
@@ -9,10 +9,10 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/go-redis/redis"
 	"github.com/openfresh/plasma/config"
 	"github.com/openfresh/plasma/event"
 	"github.com/openfresh/plasma/pubsub"
-	"gopkg.in/redis.v5"
 )
 
 type Redis struct {
@@ -97,13 +97,11 @@ func (r *Redis) receiveMessage(pb *redis.PubSub) (*redis.Message, error) {
 			return nil, fmt.Errorf("redis: unknown message: %T", msgi)
 		}
 	}
+
 }
 
 func (r *Redis) Subscribe() error {
-	ps, err := r.client.Subscribe(r.config.Channels...)
-	if err != nil {
-		return err
-	}
+	ps := r.client.Subscribe(r.config.Channels...)
 	defer ps.Close()
 	for {
 		msg, err := r.receiveMessage(ps)

--- a/subscriber/redis_test.go
+++ b/subscriber/redis_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	redis "gopkg.in/redis.v5"
+	"github.com/go-redis/redis"
 
 	"github.com/openfresh/plasma/config"
 	"github.com/openfresh/plasma/event"


### PR DESCRIPTION
Increase goroutine per request on Debug and health check endpoint.
go-redis use time.Ticker in pool, number of redis clients should be fewer.