### PR TITLE
Update proto file for Swift

### DIFF
--- a/protobuf/stream.proto
+++ b/protobuf/stream.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "openfresh.plasma";
-option objc_class_prefix = "PLASMA";
+option swift_prefix = "Plasma";
 
 package proto;
 


### PR DESCRIPTION
This PR is for use [grpc-swift](https://github.com/grpc/grpc-swift) in ![PlasmaSwift](https://github.com/openfresh/PlasmaSwift)
The default class prefix in proto compilie plugin for Swift is `Proto_`.
I prefer `Plasma` for prefix.
After merged, PlasmaSwift will download the proto from this repo and compile it.